### PR TITLE
Synchronize healtchecks and operator state

### DIFF
--- a/src/main/java/nb/kafka/operator/HealthServer.java
+++ b/src/main/java/nb/kafka/operator/HealthServer.java
@@ -2,46 +2,34 @@ package nb.kafka.operator;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.net.httpserver.HttpServer; // NOSONAR
 
-import nb.kafka.operator.model.OperatorError;
-
 @SuppressWarnings("restriction")
 public final class HealthServer {
+  private final KafkaOperator operator;
 
-  private HealthServer() {
+  public HealthServer(KafkaOperator operator) {
+    this.operator = operator;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(HealthServer.class);
 
-  public static void start(AppConfig config) throws IOException {
-    HttpServer server = HttpServer.create(new InetSocketAddress(config.getHealthsPort()), 0);
+  public void start(int port) throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
     server.createContext("/healthy", exchange -> exchange.sendResponseHeaders(200, -1));
     server.createContext("/ready", exchange -> {
-      if (isKafkaReachable(config)) {
+      if (operator.checkOperatorState()) {
         exchange.sendResponseHeaders(200, -1);
       } else {
         exchange.sendResponseHeaders(500, -1);
       }
     });
     
-    logger.info("Starting health checks server on port: {}", config.getHealthsPort());
+    logger.info("Starting health checks server on port: {}", port);
     server.start();
-  }
-
-  private static boolean isKafkaReachable(AppConfig config) {
-    try (KafkaAdmin ka = new KafkaAdminImpl(config)) {
-      ka.listTopics();
-      return true;
-    } catch (TimeoutException | InterruptedException | ExecutionException e) { // NOSONAR
-      logger.error(String.format(OperatorError.KAFKA_UNREACHABLE.toString(), config.getBootstrapServers()));
-      return false;
-    }
   }
 }

--- a/src/main/java/nb/kafka/operator/Main.java
+++ b/src/main/java/nb/kafka/operator/Main.java
@@ -27,8 +27,8 @@ public final class Main {
     setupJmxRegistry(config.getOperatorId());
     Runnable stopHttpServer = setupPrometheusRegistry(config.getMetricsPort());
 
-    HealthServer.start(config);
     KafkaOperator operator = new KafkaOperator(config);
+    new HealthServer(operator).start(config.getHealthsPort());
 
     Runtime.getRuntime().addShutdownHook(new Thread(operator::shutdown));
     Runtime.getRuntime().addShutdownHook(new Thread(stopHttpServer));

--- a/src/test/java/nb/kafka/operator/PartitionedTopicTest.java
+++ b/src/test/java/nb/kafka/operator/PartitionedTopicTest.java
@@ -1,5 +1,0 @@
-import static org.junit.Assert.*;
-
-public class PartitionedTopicTest {
-
-}


### PR DESCRIPTION
Hello,
This PR ensure that the operator state will be "FAILED" at startup when Kafka is not reachable.
Regards